### PR TITLE
docs: fix telemetry stanza for metrics endpoint

### DIFF
--- a/vault/README.md
+++ b/vault/README.md
@@ -18,7 +18,9 @@ Paste this into your terminal to just have a non TLS Vault described in this art
 ui = true
 listener "tcp" {
     address = "0.0.0.0:8200"
-    unauthenticated_metrics_access = "true"
+    telemetry {
+        unauthenticated_metrics_access = "true"
+    }
     tls_disable = 1
 }
 
@@ -46,7 +48,9 @@ EOF
 ui = true
 listener "tcp" {
     address = "0.0.0.0:8200"
-    unauthenticated_metrics_access = "true"
+    telemetry {
+        unauthenticated_metrics_access = "true"
+    }
     tls_disable = 1
 }
 


### PR DESCRIPTION
Hey @clly,
thanks for your awesome blog post :100:  . I tested the metrics endpoint under `/v1/sys/metrics` and got the following error: 
```sh
 curl -v 127.0.0.1:8200/v1/sys/metrics
*   Trying 127.0.0.1:8200...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8200 (#0)
> GET /v1/sys/metrics HTTP/1.1
> Host: 127.0.0.1:8200
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< Cache-Control: no-store
< Content-Type: application/json
< Date: Sat, 26 Sep 2020 11:05:39 GMT
< Content-Length: 49
< 
{"errors":["cannot forward local-only request"]}
```

I could fixed it with the telemetry stanza around this option (https://www.vaultproject.io/docs/configuration/listener/tcp#telemetry-parameters) . 

Afterwards:

```sh
curl -v 127.0.0.1:8200/v1/sys/metrics
*   Trying 127.0.0.1:8200...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8200 (#0)
> GET /v1/sys/metrics HTTP/1.1
> Host: 127.0.0.1:8200
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Cache-Control: no-store
< Date: Sat, 26 Sep 2020 11:15:37 GMT
< Content-Length: 608
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host 127.0.0.1 left intact
{"Timestamp":"2020-09-26 11:15:20 +0000 UTC","Gauges":[{"Name":"vault.runtime.alloc_bytes","Value":7158672,"Labels":{}},{"Name":"vault.runtime.free_count","Value":20206,"Labels":{}},{"Name":"vault.runtime.heap_objects","Value":36327,"Labels":{}},{"Name":"vault.runtime.malloc_count","Value":56533,"Labels":{}},{"Name":"vault.runtime.num_goroutines","Value":18,"Labels":{}},{"Name":"vault.runtime.sys_bytes","Value":72958210,"Labels":{}},{"Name":"vault.runtime.total_gc_pause_ns","Value":969634,"Labels":{}},{"Name":"vault.runtime.total_gc_runs","Value":3,"Labels":{}}],"Points":[],"Counters":[],"Samples":[]}
```